### PR TITLE
Fix spelling mistake in kdsingleapplicationguard.cpp

### DIFF
--- a/src/libcalamares/kdsingleapplicationguard/kdsingleapplicationguard.cpp
+++ b/src/libcalamares/kdsingleapplicationguard/kdsingleapplicationguard.cpp
@@ -723,7 +723,7 @@ void KDSingleApplicationGuard::Private::create( const QStringList & arguments )
 
     const QString name = QCoreApplication::applicationName();
     if ( name.isEmpty() ) {
-        qWarning( "KDSingleApplicationGuard: QCoreApplication::applicationName must not be emty" );
+        qWarning( "KDSingleApplicationGuard: QCoreApplication::applicationName must not be empty" );
         return;
     }
 


### PR DESCRIPTION
s/emty/empty/g.
