### PR TITLE
Add fdo keywords

### DIFF
--- a/calamares.desktop
+++ b/calamares.desktop
@@ -3,6 +3,7 @@ Type=Application
 Version=1.0
 Name=Calamares
 GenericName=System Installer
+Keywords=calamares;system;installer
 TryExec=calamares
 Exec=pkexec /usr/bin/calamares
 Comment=Calamares — System Installer


### PR DESCRIPTION
Add freedesktop.org keywords to desktop entry.

This allows users to search for the app in various desktop environments.

For more details, see:
    https://specifications.freedesktop.org/desktop-entry-spec/latest/ar01s05.html,
    https://bugs.debian.org/693918, and
    https://wiki.gnome.org/Initiatives/GnomeGoals/DesktopFileKeywords for
